### PR TITLE
Fix remark plugin--option tuple

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,9 @@ function virtualMarkdown (markdown, opts) {
 
 function loadPlugins (plugins) {
   return plugins.reduce(function (processor, plugin) {
-    plugin = Array.isArray(plugin) ? plugin[0](plugin[1] || {}) : plugin
+    if (Array.isArray(plugin)) {
+      return processor.use(plugin[0], plugin[1])
+    }
     return processor.use(plugin)
   }, remark())
 }


### PR DESCRIPTION
More info in these docs: https://github.com/wooorm/remark/blob/master/doc/remark.3.md#remarkuseplugin-options

Also: I’ll investigate whether this is a good idea to have in the main project (accepting a `<plugin, options>`) tuple. Would be [here](https://github.com/wooorm/attach-ware/blob/42a886475b586a09e7f7dbc3aaa40a73c7346895/index.js#L110).
